### PR TITLE
Fix dependancy regression in beta

### DIFF
--- a/custom_components/fuel_prices/manifest.json
+++ b/custom_components/fuel_prices/manifest.json
@@ -15,7 +15,8 @@
   "requirements": [
     "xmltodict",
     "brotli",
-    "these-united-states==1.1.0.21"
+    "these-united-states==1.1.0.21",
+    "pyfuelprices==2025.3.0b1"
   ],
   "ssdp": [],
   "version": "0.0.0",


### PR DESCRIPTION
Fixes:
```
This error originated from a custom integration.

Logger: custom_components.fuel_prices
Source: custom_components/fuel_prices/__init__.py:80
integration: Fuel Prices (documentation, issues)
First occurred: 09:56:40 (1 occurrences)
Last logged: 09:56:40

FuelPrices.create() got an unexpected keyword argument 'configuration'
```