### PR TITLE
Bump pyfuelprices to version 2025.5.0

### DIFF
--- a/custom_components/fuel_prices/manifest.json
+++ b/custom_components/fuel_prices/manifest.json
@@ -16,7 +16,7 @@
     "xmltodict",
     "brotli",
     "these-united-states==1.1.0.21",
-    "pyfuelprices==2025.4.3"
+    "pyfuelprices==2025.5.0"
   ],
   "ssdp": [],
   "version": "0.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.7.0
 # homeassistant==2024.11.0
 pip>=21.0,<23.2
 ruff==0.0.292
-pyfuelprices==2025.4.3
+pyfuelprices==2025.5.0


### PR DESCRIPTION
Update the pyfuelprices dependency to the latest version.

- Fix fuel cost calculation in PetrolSpySource by converting amount to dollars @pantherale0
- Refactor fuel price sources to improve structure and maintainability @pantherale0