### PR TITLE
Bump pyfuelprices to version 2025.5.2 and fix GasBuddy geocoder regression

### DIFF
--- a/custom_components/fuel_prices/manifest.json
+++ b/custom_components/fuel_prices/manifest.json
@@ -16,7 +16,7 @@
     "xmltodict",
     "brotli",
     "these-united-states==1.1.0.21",
-    "pyfuelprices==2025.5.1"
+    "pyfuelprices==2025.5.2"
   ],
   "ssdp": [],
   "version": "0.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.7.0
 # homeassistant==2024.11.0
 pip>=21.0,<23.2
 ruff==0.0.292
-pyfuelprices==2025.5.1
+pyfuelprices==2025.5.2


### PR DESCRIPTION
Update the pyfuelprices dependency to version 2025.5.2 and address a regression issue with the GasBuddy geocoder.