### PR TITLE
Bump pyfuelprices to version 2025.5.3

### DIFF
--- a/custom_components/fuel_prices/manifest.json
+++ b/custom_components/fuel_prices/manifest.json
@@ -16,7 +16,7 @@
     "xmltodict",
     "brotli",
     "these-united-states==1.1.0.21",
-    "pyfuelprices==2025.5.2"
+    "pyfuelprices==2025.5.3"
   ],
   "ssdp": [],
   "version": "0.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.7.0
 # homeassistant==2024.11.0
 pip>=21.0,<23.2
 ruff==0.0.292
-pyfuelprices==2025.5.2
+pyfuelprices==2025.5.3


### PR DESCRIPTION
Update the dependency for pyfuelprices to the latest version.

- Finelly: Remove unused imports and allow configurable data source interval @pantherale0