### PR TITLE
Update pyfuelprices to version 2026.2.0

### DIFF
--- a/custom_components/fuel_prices/manifest.json
+++ b/custom_components/fuel_prices/manifest.json
@@ -16,7 +16,7 @@
     "xmltodict",
     "brotli",
     "these-united-states==1.1.0.21",
-    "pyfuelprices==2025.11.1"
+    "pyfuelprices==2026.2.0"
   ],
   "ssdp": [],
   "version": "0.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.7.0
 homeassistant==2025.7.0
 pip>=21.0,<23.2
 ruff==0.0.292
-pyfuelprices==2025.11.0
+pyfuelprices==2026.2.0


### PR DESCRIPTION
Update the dependency for pyfuelprices to the latest version, ensuring compatibility and access to new features and fixes.